### PR TITLE
Use annotationProcessor instead of apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ compile 'com.github.car2go.Endpoint2mock:endpoint2mock:1.1.0'
 kapt 'com.github.car2go.Endpoint2mock:endpoint2mock-compiler:1.1.0'
 
 // If you do not use Kotlin
-apt 'com.github.car2go.Endpoint2mock:endpoint2mock-compiler:1.1.0'
+annotationProcessor 'com.github.car2go.Endpoint2mock:endpoint2mock-compiler:1.1.0'
 ```
 
 ### Step three


### PR DESCRIPTION
As of the Android Gradle plugin version 2.2, all functionality that was previously provided by android-apt is now available in the Android plugin. Android Gradle 2.3 is actively blocking android-apt now in anticipation of upcoming changes to the Android Gradle plugin. This means that android-apt is officially obsolete ;)

https://bitbucket.org/hvisser/android-apt/wiki/Migration